### PR TITLE
Android HDR | Add ability to transform 10-bit content to 8-bit content

### DIFF
--- a/TextureViewtoSurfaceView/app/build.gradle
+++ b/TextureViewtoSurfaceView/app/build.gradle
@@ -44,6 +44,10 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
 
+    // ExoPLayer
+    implementation 'com.google.android.exoplayer:exoplayer-core:2.18.2'
+    implementation 'com.google.android.exoplayer:exoplayer-transformer:2.18.2'
+
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.4'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'

--- a/TextureViewtoSurfaceView/app/build.gradle
+++ b/TextureViewtoSurfaceView/app/build.gradle
@@ -39,16 +39,17 @@ android {
 dependencies {
 
     implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'androidx.appcompat:appcompat:1.6.0'
     implementation 'com.google.android.material:material:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
 
-    // ExoPLayer
-    implementation 'com.google.android.exoplayer:exoplayer-core:2.18.2'
-    implementation 'com.google.android.exoplayer:exoplayer-transformer:2.18.2'
+    // Media3
+    def media3_version = "1.0.0-beta03"
+    implementation "androidx.media3:media3-common:$media3_version"
+    implementation "androidx.media3:media3-transformer:$media3_version"
 
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/TextureViewtoSurfaceView/app/src/main/AndroidManifest.xml
+++ b/TextureViewtoSurfaceView/app/src/main/AndroidManifest.xml
@@ -31,5 +31,6 @@
         <activity android:name=".examples.single.SurfaceViewVideoPlayerHDR" />
         <activity android:name=".examples.multi.MultiViewVideoPlayer" />
         <activity android:name=".examples.multi.MultiViewVideoPlayerHDR" />
+        <activity android:name=".examples.multi.MultiViewVideoPlayerHDRTransformer" />
     </application>
 </manifest>

--- a/TextureViewtoSurfaceView/app/src/main/java/com/android/textureview_surfaceview/MainActivity.kt
+++ b/TextureViewtoSurfaceView/app/src/main/java/com/android/textureview_surfaceview/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.android.textureview_surfaceview.databinding.ActivityMainBinding
 import com.android.textureview_surfaceview.examples.multi.MultiViewVideoPlayer
 import com.android.textureview_surfaceview.examples.multi.MultiViewVideoPlayerHDR
+import com.android.textureview_surfaceview.examples.multi.MultiViewVideoPlayerHDRTransformer
 import com.android.textureview_surfaceview.examples.single.SurfaceViewVideoPlayer
 import com.android.textureview_surfaceview.examples.single.SurfaceViewVideoPlayerHDR
 import com.android.textureview_surfaceview.examples.single.TextureViewVideoPlayer
@@ -46,6 +47,11 @@ class MainActivity : AppCompatActivity() {
 
         binding.multiViewVideoPlayersHdr.setOnClickListener {
             val intent = Intent(this, MultiViewVideoPlayerHDR::class.java)
+            startActivity(intent)
+        }
+
+        binding.multiViewVideoPlayersHdrTransformer.setOnClickListener {
+            val intent = Intent(this, MultiViewVideoPlayerHDRTransformer::class.java)
             startActivity(intent)
         }
     }

--- a/TextureViewtoSurfaceView/app/src/main/java/com/android/textureview_surfaceview/decoder/CustomVideoDecoder.kt
+++ b/TextureViewtoSurfaceView/app/src/main/java/com/android/textureview_surfaceview/decoder/CustomVideoDecoder.kt
@@ -2,7 +2,6 @@ package com.android.textureview_surfaceview.decoder
 
 import android.content.res.AssetFileDescriptor
 import android.media.MediaCodec
-import android.media.MediaCodecInfo
 import android.media.MediaCodecList
 import android.media.MediaExtractor
 import android.media.MediaExtractor.SEEK_TO_PREVIOUS_SYNC
@@ -28,6 +27,19 @@ class CustomVideoDecoder(
         fun buildWithAssetFile(assetFile: AssetFileDescriptor): CustomVideoDecoder {
             val extractor = MediaExtractor()
             extractor.setDataSource(assetFile)
+            return buildCustomVideoDecoder(extractor)
+        }
+
+        /**
+         * Companion builder object used to construct a [CustomVideoDecoder] using a String path.
+         */
+        fun buildWithFilePath(name: String): CustomVideoDecoder {
+            val extractor = MediaExtractor()
+            extractor.setDataSource(name)
+            return buildCustomVideoDecoder(extractor)
+        }
+
+        private fun buildCustomVideoDecoder(extractor: MediaExtractor): CustomVideoDecoder {
             for (i in 0 until extractor.trackCount) {
                 val format = extractor.getTrackFormat(i)
                 format.getString(MediaFormat.KEY_MIME)?.let {

--- a/TextureViewtoSurfaceView/app/src/main/java/com/android/textureview_surfaceview/examples/multi/MultiViewVideoPlayerHDRTransformer.kt
+++ b/TextureViewtoSurfaceView/app/src/main/java/com/android/textureview_surfaceview/examples/multi/MultiViewVideoPlayerHDRTransformer.kt
@@ -10,15 +10,16 @@ import android.view.Surface
 import android.view.SurfaceHolder
 import android.view.TextureView
 import android.widget.Toast
+import androidx.media3.common.MediaItem
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.transformer.*
+import androidx.media3.transformer.Transformer.PROGRESS_STATE_NO_TRANSFORMATION
 import com.android.textureview_surfaceview.Constants
 import com.android.textureview_surfaceview.databinding.MultiViewPlayerHdrTransformerBinding
 import com.android.textureview_surfaceview.decoder.CustomVideoDecoder
-import com.google.android.exoplayer2.MediaItem
-import com.google.android.exoplayer2.transformer.*
-import com.google.android.exoplayer2.transformer.Transformer.PROGRESS_STATE_NO_TRANSFORMATION
-import com.google.android.exoplayer2.transformer.Transformer.ProgressState
 import java.util.*
 
+@UnstableApi
 class MultiViewVideoPlayerHDRTransformer : Activity(), SurfaceHolder.Callback,
     TextureView.SurfaceTextureListener, Transformer.Listener {
 
@@ -89,7 +90,8 @@ class MultiViewVideoPlayerHDRTransformer : Activity(), SurfaceHolder.Callback,
         val mainHandler = Handler(applicationContext.mainLooper)
         mainHandler.post(object : Runnable {
             override fun run() {
-                val progressState: @ProgressState Int = transformer.getProgress(progressHolder)
+                val progressState: @Transformer.ProgressState Int =
+                    transformer.getProgress(progressHolder)
                 if (progressState != PROGRESS_STATE_NO_TRANSFORMATION) {
                     binding.textureViewTitle.text =
                         "Transformation Progress = ${progressHolder.progress}"

--- a/TextureViewtoSurfaceView/app/src/main/java/com/android/textureview_surfaceview/examples/multi/MultiViewVideoPlayerHDRTransformer.kt
+++ b/TextureViewtoSurfaceView/app/src/main/java/com/android/textureview_surfaceview/examples/multi/MultiViewVideoPlayerHDRTransformer.kt
@@ -1,0 +1,147 @@
+package com.android.textureview_surfaceview.examples.multi
+
+import android.app.Activity
+import android.graphics.SurfaceTexture
+import android.net.Uri
+import android.os.Bundle
+import android.os.Handler
+import android.util.Log
+import android.view.Surface
+import android.view.SurfaceHolder
+import android.view.TextureView
+import android.widget.Toast
+import com.android.textureview_surfaceview.Constants
+import com.android.textureview_surfaceview.databinding.MultiViewPlayerHdrTransformerBinding
+import com.android.textureview_surfaceview.decoder.CustomVideoDecoder
+import com.google.android.exoplayer2.MediaItem
+import com.google.android.exoplayer2.transformer.*
+import com.google.android.exoplayer2.transformer.Transformer.PROGRESS_STATE_NO_TRANSFORMATION
+import com.google.android.exoplayer2.transformer.Transformer.ProgressState
+import java.util.*
+
+class MultiViewVideoPlayerHDRTransformer : Activity(), SurfaceHolder.Callback,
+    TextureView.SurfaceTextureListener, Transformer.Listener {
+
+    private lateinit var binding: MultiViewPlayerHdrTransformerBinding
+    private lateinit var transformer: Transformer
+
+    // Decoders
+    private var surfaceViewDecoder: CustomVideoDecoder? = null
+    private var textureViewDecoder: CustomVideoDecoder? = null
+
+    // Random File name
+    private lateinit var encodedFile: String
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = MultiViewPlayerHdrTransformerBinding.inflate(layoutInflater)
+
+        /// File Name
+        encodedFile = applicationContext.cacheDir.absolutePath + "/" + UUID.randomUUID().toString()
+        binding.surfaceView.setAspectRatio(16, 9)
+        binding.surfaceView.holder.addCallback(this)
+        binding.textureView.setAspectRatio(16, 9)
+        binding.textureView.surfaceTextureListener = this
+
+        /// Set up transformer using Transformer.Builder
+        val request = TransformationRequest.Builder()
+            .setEnableRequestSdrToneMapping(true)
+            .build()
+
+        transformer = Transformer.Builder(applicationContext)
+            .setTransformationRequest(request)
+            .addListener(this)
+            .build()
+
+        setContentView(binding.root)
+    }
+
+    override fun onDestroy() {
+        textureViewDecoder?.stop()
+        surfaceViewDecoder?.stop()
+        super.onDestroy()
+    }
+
+    /** SurfaceHolder.Callback Overrides */
+    override fun surfaceCreated(holder: SurfaceHolder) {
+        val assetFile = applicationContext.assets.openFd(Constants.HDR_VIDEO_PLAYER_ASSET)
+        surfaceViewDecoder = CustomVideoDecoder.buildWithAssetFile(assetFile)
+        surfaceViewDecoder?.setSurface(holder.surface)
+        surfaceViewDecoder?.start(loop = true)
+    }
+
+    override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {
+        // No-Op.
+    }
+
+    override fun surfaceDestroyed(holder: SurfaceHolder) {
+        surfaceViewDecoder?.stop()
+    }
+
+    /** TextureView.SurfaceTextureListener Overrides */
+    override fun onSurfaceTextureAvailable(surface: SurfaceTexture, width: Int, height: Int) {
+        val firstVideoUri = Uri.parse("asset:///" + Constants.HDR_VIDEO_PLAYER_ASSET)
+        val item = MediaItem.fromUri(firstVideoUri)
+        transformer.startTransformation(item, encodedFile)
+
+        // Set up to update UI of progress
+        val progressHolder = ProgressHolder()
+        val mainHandler = Handler(applicationContext.mainLooper)
+        mainHandler.post(object : Runnable {
+            override fun run() {
+                val progressState: @ProgressState Int = transformer.getProgress(progressHolder)
+                if (progressState != PROGRESS_STATE_NO_TRANSFORMATION) {
+                    binding.textureViewTitle.text =
+                        "Transformation Progress = ${progressHolder.progress}"
+                    mainHandler.postDelayed( /* r = */ this,  /* delayMillis = */16)
+                }
+            }
+        })
+    }
+
+    override fun onSurfaceTextureSizeChanged(surface: SurfaceTexture, width: Int, height: Int) {
+        // No-Op
+    }
+
+    override fun onSurfaceTextureDestroyed(surface: SurfaceTexture): Boolean {
+        textureViewDecoder?.stop()
+        return true
+    }
+
+    override fun onSurfaceTextureUpdated(surface: SurfaceTexture) {
+        // No-Op
+    }
+
+    /** Transformer.Listener Overrides */
+    override fun onTransformationCompleted(
+        inputMediaItem: MediaItem, transformationResult: TransformationResult
+    ) {
+        textureViewDecoder = CustomVideoDecoder.buildWithFilePath(encodedFile)
+        textureViewDecoder?.setSurface(Surface(binding.textureView.surfaceTexture))
+        textureViewDecoder?.start(loop = true)
+    }
+
+    override fun onTransformationError(
+        inputMediaItem: MediaItem, exception: TransformationException
+    ) {
+        val message = "Transformation Failed... ${exception.cause}"
+        Log.e(MultiViewVideoPlayerHDRTransformer::class.java.name, message)
+
+        val mainHandler = Handler(applicationContext.mainLooper)
+        mainHandler.post { binding.textureViewTitle.text = message }
+
+        Toast.makeText(applicationContext, message, Toast.LENGTH_LONG).show()
+    }
+
+    override fun onFallbackApplied(
+        inputMediaItem: MediaItem,
+        originalTransformationRequest: TransformationRequest,
+        fallbackTransformationRequest: TransformationRequest
+    ) {
+        Log.w(
+            MultiViewVideoPlayerHDRTransformer::class.java.name,
+            "Fallback applied: $fallbackTransformationRequest"
+        )
+    }
+}
+

--- a/TextureViewtoSurfaceView/app/src/main/res/layout/activity_main.xml
+++ b/TextureViewtoSurfaceView/app/src/main/res/layout/activity_main.xml
@@ -113,4 +113,15 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/multi_view_video_players" />
 
+    <Button
+        android:id="@+id/multi_view_video_players_hdr_transformer"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:text="@string/main_activity_multi_player_view_hdr_transformer"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/multi_view_video_players_hdr" />
+
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/TextureViewtoSurfaceView/app/src/main/res/layout/multi_view_player_hdr_transformer.xml
+++ b/TextureViewtoSurfaceView/app/src/main/res/layout/multi_view_player_hdr_transformer.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/black"
+    tools:context=".examples.multi.MultiViewVideoPlayer">
+
+    <TextView
+        android:id="@+id/surfaceViewTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Surface View (Custom Decoder)"
+        android:textColor="@color/white"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.497"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.android.textureview_surfaceview.views.FixedAspectSurfaceView
+        android:id="@+id/surfaceView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/surfaceViewTitle" />
+
+    <TextView
+        android:id="@+id/textureViewTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="Texture View (Custom Decoder)"
+        android:textColor="@color/white"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.497"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/surfaceView" />
+
+    <com.android.textureview_surfaceview.views.FixedAspectTextureView
+        android:id="@+id/textureView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/textureViewTitle" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/TextureViewtoSurfaceView/app/src/main/res/values/strings.xml
+++ b/TextureViewtoSurfaceView/app/src/main/res/values/strings.xml
@@ -8,4 +8,5 @@
     <string name="main_activity_surface_view_hdr">SurfaceView (HLG 10-Bit) VideoPlayer</string>
     <string name="main_activity_multi_player_view">Multi Player (Non-HDR)</string>
     <string name="main_activity_multi_player_view_hdr">Multi Player (HDR Content)</string>
+    <string name="main_activity_multi_player_view_hdr_transformer">Multi Player (HDR Content, Transformed)</string>
 </resources>


### PR DESCRIPTION
# Description
This CL contains sample code on how a developer can use the Transformer API to transcode 10-bit HDR files to 8-bit SDR files for compatibility with TextureView as well as older devices.

On devices that are  API 32 and below, 10-Bit content on a TextureView will produce 'Color Washout' which shows itself as desaturated colors within a video file.
![image1](https://user-images.githubusercontent.com/5649571/211418535-4a480376-5986-4083-9111-696e872508a0.png)

With the TransformerAPI, a developer can transcode the content to 8-bit so that it is compatible with other devices that may not be able to decode 10-bit HDR content as well as TextureView Display.

![ezgif com-gif-maker](https://user-images.githubusercontent.com/5649571/211419430-f4bbf8a4-9772-453d-98d1-b732e7e838d4.gif)

# How Has This Been Tested?
This sample app was tested on 3 devices on 3 different version of android:

**Test Configuration #1 - Pixel 6 Pro**:
* SDK Version : API 33 (Android 13)
* HDR Capable screen?: Yes

**Test Configuration #2 - Samsung Galaxy s22 Ultra **:
* SDK Version : API 31 (Android 12)
* HDR Capable screen?: Yes
* 
**Test Configuration #3 - Pixel 5a With 5G**:
* SDK Version : API 30 (Android 11)
* HDR Capable screen?: Yes

# Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation